### PR TITLE
Store PDF in FHIR using DocumentReference, Encounter and EpisodeOfCare resources

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-# Copyright (C) 2018  Atos Spain SA. All rights reserved.
+# Copyright (C) 2020  Atos Spain SA. All rights reserved.
 # 
-# This file is part of the KeyCloak Auth API.
+# This file is part of the REDCap Report Listener.
 # 
 # This file is free software: you can redistribute it and/or modify it under the 
 # terms of the Apache License, Version 2.0 (the License);

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ mvn clean package
 and execute
 
 ```
-java -jar target/xcare-listener.jar
+java -jar target/redcap-report-listener.jar
 ```
 
 It can also be run as:
@@ -44,11 +44,20 @@ mvn spring-boot:run
 
 ## Environment variables
 
-	ORU_URL=
-	REDCAP_URL=
+	HIS_BASE_URL=
+	HIS_USER=
+	HIS_PASSWORD=
+	REDCAP_BASE_URL=
 	REDCAP_TOKEN=
-	REDCAP_INSTRUMENT=
-	FHIR_URL=
+	REDCAP_REPORT_INSTRUMENTS=
+	REDCAP_REPORT_NAMES=
+	REDCAP_FORMAT=
+	REDCAP_TYPE=
+	REDCAP_XML_FORMAT=
+	REDCAP_XML_TYPE=
+	REDCAP_LISTENER=
+	REDCAP_LANGUAGE=
+	FHIR_BASE_URL=
     LOGGING_FOLDER=
     LOGGING_MODE=
 
@@ -57,19 +66,19 @@ mvn spring-boot:run
 Build the image:
 
 ```
-docker build -t health/xcare-listener .
+docker build -t health/redcap-report-listener .
 ```
 
 Simple deployment:
 
 ```
-docker run --name xcare-listener -d health/xcare-listener
+docker run --name redcap-report-listener -d health/redcap-report-listener
 ```
 
 Logging can be also configured using `LOGGING_FOLDER` and sharing a volume (this is useful for example for [ELK](https://www.elastic.co/elk-stack) processing). The level of the logging can be configured with `LOGGING_MODE` (dev|prod):
 
 ```
-docker run --name xcare-listener -d -v /tmp/log/xcare-listener:/log/xcare-listener -e LOGGING_FOLDER=/log/test -e LOGGING_MODE=dev health/xcare-listener
+docker run --name recap-report-listener -d -v /tmp/log/redcap-report-listener:/log/redcap-report-listener -e LOGGING_FOLDER=/log/test -e LOGGING_MODE=dev health/redcap-report-listener
 ```
 
 ## License

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>net.atos.ari.sdk</groupId>
     <artifactId>redcap-report-listener</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>redcap-report-listener</name>

--- a/src/main/java/net/atos/ari/sdk/client/Client.java
+++ b/src/main/java/net/atos/ari/sdk/client/Client.java
@@ -68,6 +68,7 @@ public class Client extends WebServiceGatewaySupport {
     private final static String DATE_FORMAT_BIRTHDATE = "yyyyMMdd";
     
 
+    private static final String SOURCE_CLINIC = "http://clinic.cat";
     private static final String SOURCE_ORU = "http://orusap.org";
     private static final String SOURCE_EPISODE = "ANE";
     private static final String SOURCE_CIP = "http://cip.org";
@@ -77,11 +78,11 @@ public class Client extends WebServiceGatewaySupport {
     @Value("${his.doctor.id}")
     private String defaultDoctorId;
     
-    public ORUR01 createORU(String nhcPatient, Patient fhirPatient, 
+    public ORUR01 createORU(Patient fhirPatient, 
         Encounter encounter, EpisodeOfCare episodeOfCare, String reportName) {
         
 
-        String sapId = "", cip = "", episode = "", placeOrder = "";
+        String sapId = "", cip = "", episode = "", placeOrder = "", nhcPatient = "";
         if (episodeOfCare != null)
             for (Identifier mpi : episodeOfCare.getIdentifier()) {
                 if (SOURCE_EPISODE.equalsIgnoreCase(mpi.getSystem()) == true)
@@ -93,6 +94,8 @@ public class Client extends WebServiceGatewaySupport {
                 sapId = mpi.getValue();
             if (SOURCE_CIP.equalsIgnoreCase(mpi.getSystem()) == true)
                 cip = mpi.getValue();
+            if (SOURCE_CLINIC.equalsIgnoreCase(mpi.getSystem()) == true)
+                nhcPatient = mpi.getValue();
         }
 
         if (encounter != null)
@@ -356,34 +359,14 @@ public class Client extends WebServiceGatewaySupport {
 
         oruObject.setORUR01PATIENTRESULT(patientResult);
         
-        // TODO
-        // Remove this snippet
-        
-        JAXBContext contextObj;
-        try {
-            contextObj = JAXBContext.newInstance(ORUR01.class);
-            Marshaller marshallerObj = contextObj.createMarshaller();  
-            marshallerObj.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true);  
-            
-            StringWriter sw = new StringWriter();
-            marshallerObj.marshal(oruObject, sw);        
-            String xmlString = sw.toString();
-            
-            logger.info(xmlString);
-        } catch (JAXBException e) {
-            // TODO Auto-generated catch block
-            e.printStackTrace();
-        } 
-        
         return oruObject;
     }
 
     @SuppressWarnings("unchecked")
-    public ACK setORU(String nhc, Patient patient, String reportName, 
+    public ACK setORU(Patient patient, String reportName, 
         Encounter encounter, EpisodeOfCare episode, byte[] encodedBytes) {
         
-        ORUR01 oruObject = createORU(nhc, patient, 
-            encounter, episode, reportName);
+        ORUR01 oruObject = createORU(patient, encounter, episode, reportName);
 
         String pdfInBase64 = new String(encodedBytes);
 

--- a/src/main/java/net/atos/ari/sdk/config/ClientConfig.java
+++ b/src/main/java/net/atos/ari/sdk/config/ClientConfig.java
@@ -18,13 +18,13 @@ public class ClientConfig {
 
     private static final Logger logger = LoggerFactory.getLogger(ClientConfig.class);
 
-    @Value("${client.default-uri}")
+    @Value("${his.default-uri}")
     private String defaultUri;
 
-    @Value("${client.user.name}")
+    @Value("${his.user.name}")
     private String userName;
 
-    @Value("${client.user.password}")
+    @Value("${his.user.password}")
     private String userPassword;
 
     @Bean

--- a/src/main/java/net/atos/ari/sdk/service/FHIRListenerService.java
+++ b/src/main/java/net/atos/ari/sdk/service/FHIRListenerService.java
@@ -75,8 +75,8 @@ public class FHIRListenerService implements ListenerService {
     private final String CATEGORY_CODE = "activity";
     private final String CLINIC = "http://clinic.org";
 
-    private final String PREHAB_CODE = "http://clinic.org";
-    private final String PREHAB_DISPLAY = "http://clinic.org";
+    private final String PREHAB_CODE = "102PH";
+    private final String PREHAB_DISPLAY = "VISITA PRE-HABILITACIO";
 
     /** FHIR base url path. */
     @Value("${fhir.base.url}")

--- a/src/main/java/net/atos/ari/sdk/service/REDCapListenerService.java
+++ b/src/main/java/net/atos/ari/sdk/service/REDCapListenerService.java
@@ -146,16 +146,17 @@ public class REDCapListenerService implements ListenerService {
                 respCode = resp.getStatusLine()
                     .getStatusCode();
 
-            BufferedReader reader = new BufferedReader(new InputStreamReader(resp.getEntity()
-                .getContent()));
-            result = reader.lines()
-                .collect(Collectors.joining());
-
             if (respCode != 200) {
                 manageError(respCode, resp.getStatusLine()
                     .getReasonPhrase());
                 return null;
             }        
+
+            BufferedReader reader = new BufferedReader(new InputStreamReader(resp.getEntity()
+                .getContent()));
+            result = reader.lines()
+                .collect(Collectors.joining());
+
         } catch (final Exception e) {
             logger.error(e.getMessage(), e);
             return null;

--- a/src/main/java/net/atos/ari/sdk/service/REDCapListenerService.java
+++ b/src/main/java/net/atos/ari/sdk/service/REDCapListenerService.java
@@ -42,6 +42,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.InputStream;
@@ -216,14 +217,17 @@ public class REDCapListenerService implements ListenerService {
             InputStream is = resp.getEntity()
                 .getContent();
             // FileOutputStream fos = new FileOutputStream(new File("export.pdf"));
-            //int read;
-            //final byte[] buf = new byte[4096];
-            //while ((read = is.read(buf)) > 0)
-                // fos.write(buf, 0, read);
-            // fos.close();
-            // is.close();
+            ByteArrayOutputStream buffer = new ByteArrayOutputStream();
             
-            return is.readAllBytes();
+            int read;
+            final byte[] buf = new byte[4096];
+            while ((read = is.read(buf)) > 0)
+                buffer.write(buf, 0, read);
+            
+            buffer.close();
+            is.close();
+            
+            return buffer.toByteArray();
         } catch (final Exception e) {
             logger.error(e.getMessage(), e);
             return null;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,11 +5,13 @@ spring:
     serialization:
       INDENT_OUTPUT: true
 
-client:
+his:
   default-uri: ${HIS_BASE_URL:https://localhost/oru}
   user:
     name: ${HIS_USER:test}
     password: ${HIS_PASSWORD:test}
+  doctor:
+    id: test
 
 redcap:
   base:
@@ -26,8 +28,17 @@ redcap:
       type:  ${REDCAP_XML_TYPE:eav}
   listener:
     timer:  ${REDCAP_LISTENER:60000}
-    
+  language: ${REDCAP_LANGUAGE:EN}
+
+# 769681006 - First patient encounter
+# 275647001 - Discharged from follow-up
 fhir:
   base:
-    url: ${FHIR_BASE_URL:http://localhost:8080/hapi-fhir/baseDstu3}
+    url: ${FHIR_BASE_URL:http://localhost:8080/hapi-fhir-jpaserver/fhir/}
+  encounter:
+    codes: ${FHIR_ENCOUNTER_CODES:769681006,275647001}
+    display: ${FHIR_ENCOUNTER_DISPLAYS:First patient encounter,Discharged from follow-up}
+  document:
+    codes: ${FHIR_DOCUMENT_CODES:47039-3,28655-9}
+    display: ${FHIR_DOCUMENT_DISPLAYS:Hospital Admission history and physical note,Discharge Summary from Responsible Clinician}
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,8 +37,8 @@ fhir:
     url: ${FHIR_BASE_URL:http://localhost:8080/hapi-fhir-jpaserver/fhir/}
   encounter:
     codes: ${FHIR_ENCOUNTER_CODES:769681006,275647001}
-    display: ${FHIR_ENCOUNTER_DISPLAYS:First patient encounter,Discharged from follow-up}
+    displays: ${FHIR_ENCOUNTER_DISPLAYS:First patient encounter,Discharged from follow-up}
   document:
     codes: ${FHIR_DOCUMENT_CODES:47039-3,28655-9}
-    display: ${FHIR_DOCUMENT_DISPLAYS:Hospital Admission history and physical note,Discharge Summary from Responsible Clinician}
+    displays: ${FHIR_DOCUMENT_DISPLAYS:Hospital Admission history and physical note,Discharge Summary from Responsible Clinician}
 

--- a/src/test/java/net/atos/ari/sdk/ORUServiceTest.java
+++ b/src/test/java/net/atos/ari/sdk/ORUServiceTest.java
@@ -19,6 +19,6 @@ public class ORUServiceTest {
     @Test
     @Ignore
     public void givenORU_whenServiceStarts_thenReturnOK() {
-        ORUR01 oruObject = client.createORU("", new Patient(), "");
+        ORUR01 oruObject = client.createORU("", new Patient(), null, null, "");
     }
 }

--- a/src/test/java/net/atos/ari/sdk/ORUServiceTest.java
+++ b/src/test/java/net/atos/ari/sdk/ORUServiceTest.java
@@ -19,6 +19,6 @@ public class ORUServiceTest {
     @Test
     @Ignore
     public void givenORU_whenServiceStarts_thenReturnOK() {
-        ORUR01 oruObject = client.createORU("", new Patient(), null, null, "");
+        ORUR01 oruObject = client.createORU(new Patient(), null, null, "");
     }
 }


### PR DESCRIPTION
## Proposed Changes

- The pdf documents should be stored in FHIR
- We use this information to generate the ORU message
- We need other information such as the episode id, the service request id and the place holder

## Pull request checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests
- [x] Build locally
- [X] Code format / lint
- [ ] Docs have been reviewed and added

## Pull request type

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 

## What is the current behavior?

Fixes #1 

## What is the new behavior?

- Cover different pdfs generation (program inclusion and discharge)
- Store the resources into FHIR (checking that they already exist)
- Use Encounter and EpisodeOfCare resources for the ORU to work

## Does this introduce a breaking change?

- [ ] Yes
- [x] No